### PR TITLE
Add ruff formatting and mypy workflow

### DIFF
--- a/.github/workflows/mypy.yml
+++ b/.github/workflows/mypy.yml
@@ -1,4 +1,4 @@
-name: Ruff Lint
+name: Mypy
 
 on:
   pull_request:
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  lint:
+  mypy:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -14,8 +14,6 @@ jobs:
         with:
           python-version: '3.11'
       - name: Install dependencies
-        run: pip install ruff
-      - name: Check formatting
-        run: ruff format --check .
-      - name: Run ruff lint
-        run: ruff check .
+        run: pip install mypy
+      - name: Run mypy
+        run: mypy nasdaq_data_link_mcp_os

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,19 @@
+name: Ruff Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: pip install ruff
+      - name: Run ruff
+        run: ruff check .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM python:3.13-slim
+
+# Install server dependencies
+RUN pip install --no-cache-dir "mcp[cli]" nasdaq-data-link pycountry
+
+# Copy source
+WORKDIR /app
+COPY . .
+
+# Default env file
+COPY .env.example .env
+
+# Ensure local package is discoverable
+ENV PYTHONPATH=/app
+
+# The server requires NASDAQ_DATA_LINK_API_KEY to be set at runtime
+CMD ["mcp", "install", "nasdaq_data_link_mcp_os/server.py", "--env-file", ".env", "--name", "Nasdaq Data Link MCP Server", "--with", "nasdaq-data-link", "--with", "pycountry"]

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 </div>
 
-A community developed and maintained [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server that provides access to [Nasdaq Data Link](https://data.nasdaq.com/). Built for use with MCP-compatible [clients](https://modelcontextprotocol.io/clients).
+A community developed and maintained [Model Context Protocol (MCP)](https://github.com/modelcontextprotocol) server that provides access for large language models to the [Nasdaq Data Link](https://data.nasdaq.com/). Built for use with MCP-compatible [clients](https://modelcontextprotocol.io/clients).
 
 This project aims at making easy to access and explore Nasdaq Data Link’s extensive and valuable financial and economic datasets through natural language interfaces and large language models (LLMs).
 

--- a/README.md
+++ b/README.md
@@ -26,12 +26,6 @@ This project aims at making easy to access and explore Nasdaq Data Link’s exte
 > [!IMPORTANT]
 > This is an open-source project *not affiliated with or endorsed by Nasdaq, Inc.* Nasdaq® is a registered trademark of Nasdaq, Inc.
 
-> [!TIP]
-> If you use this project in your research or work, please cite it using the [CITATION.cff](CITATION.cff) file, or the APA format:
-
-`Amorelli, S. (2025). Nasdaq Data Link MCP (Model Context Protocol) Server [Computer software]. GitHub. https://github.com/stefanoamorelli/nasdaq-data-link-mcp`
-
-
 ## 🌐 Usage
 
 | [![Retail Trading Activity](https://cdn.loom.com/sessions/thumbnails/b0299f6f6f1844669b5d2f73a86a3dcb-63f0e754bafcbe42-full-play.gif)](https://www.loom.com/share/b0299f6f6f1844669b5d2f73a86a3dcb) | [![World Bank Data](https://cdn.loom.com/sessions/thumbnails/a07e518bb6eb4de4b5a06a5a1a112a24-ff58182656db7dca-full-play.gif)](https://www.loom.com/share/a07e518bb6eb4de4b5a06a5a1a112a24) |
@@ -39,6 +33,11 @@ This project aims at making easy to access and explore Nasdaq Data Link’s exte
 | [Nasdaq Data Link MCP - Retail Trading Activity](https://www.loom.com/share/b0299f6f6f1844669b5d2f73a86a3dcb) | [Nasdaq Data Link MCP - World Bank Data](https://www.loom.com/share/a07e518bb6eb4de4b5a06a5a1a112a24) |
 | [![Retail Trading Activity](https://cdn.loom.com/sessions/thumbnails/46c7df4cb4c4405aa9e0a49ce6cd75be-9a5eeaf2133bc160-full-play.gif)](https://www.loom.com/share/46c7df4cb4c4405aa9e0a49ce6cd75be) | |
 | [Nasdaq Data Link MCP - Groq + DeepSeek R1 RTAT 10](https://www.loom.com/share/46c7df4cb4c4405aa9e0a49ce6cd75be) | | 
+
+> [!TIP]
+> If you use this project in your research or work, please cite it using the [CITATION.cff](CITATION.cff) file, or the APA format:
+
+`Amorelli, S. (2025). Nasdaq Data Link MCP (Model Context Protocol) Server [Computer software]. GitHub. https://github.com/stefanoamorelli/nasdaq-data-link-mcp`
 
 Once installed and connected to an `MCP`-compatible client (e.g., [Claude Desktop](https://claude.ai/download), or [Groq Desktop (beta)](https://github.com/groq/groq-desktop-beta), this server exposes several tools that your AI assistant can use to fetch data.
 

--- a/README.md
+++ b/README.md
@@ -167,6 +167,19 @@ docker run -e NASDAQ_DATA_LINK_API_KEY="your_api_key_here" stefanoamorelli/nasda
 
 The container automatically launches the MCP server defined in `nasdaq_data_link_mcp_os/server.py`, so once it starts you can connect to it just like the manual setup.
 
+### Cline example
+
+See the [Cline documentation](https://docs.cline.bot/mcp-servers/configuring-mcp-servers#editing-mcp-settings-files)
+for instructions on managing MCP configuration.
+
+Provide Cline with the following information:
+
+```
+I want to add the MCP server for Nasdaq Data Link.
+Here's the GitHub link: @https://github.com/stefanoamorelli/nasdaq-data-link-mcp
+Can you add it?
+```
+
 ---
 
 ## 🛠️ Tools

--- a/README.md
+++ b/README.md
@@ -156,6 +156,17 @@ uv run mcp install nasdaq_data_link_mcp_os/server.py --env-file .env --name "Nas
 
 This registers the server with your MCP client (e.g., Claude Desktop).
 
+### Docker 🐳
+
+If you prefer using a container, a prebuilt image is available on [Docker Hub](https://hub.docker.com/repository/docker/stefanoamorelli/nasdaq-data-link-mcp/tags/latest/). Pull the latest image and run it with your Nasdaq Data Link API key:
+
+```bash
+docker pull stefanoamorelli/nasdaq-data-link-mcp:latest
+docker run -e NASDAQ_DATA_LINK_API_KEY="your_api_key_here" stefanoamorelli/nasdaq-data-link-mcp:latest
+```
+
+The container automatically launches the MCP server defined in `nasdaq_data_link_mcp_os/server.py`, so once it starts you can connect to it just like the manual setup.
+
 ---
 
 ## 🛠️ Tools

--- a/nasdaq_data_link_mcp_os/resources/equities_360/balance_sheet.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/balance_sheet.py
@@ -7,23 +7,23 @@ def get_balance_sheet(
     symbol: Optional[str] = None,
     figi: Optional[str] = None,
     calendardate: Optional[str] = None,
-    dimension: Optional[str] = None
+    dimension: Optional[str] = None,
 ) -> Union[pd.DataFrame, str]:
     """
     Fetch balance sheet data from Nasdaq Data Link E360 NDAQ/BS table.
-    
+
     Args:
         symbol: Stock ticker symbol (e.g., 'AAPL', 'MSFT')
         figi: Bloomberg FIGI identifier (e.g., 'BBG000BPH459')
         calendardate: Calendar date in YYYY-MM-DD format
         dimension: MRQ (Quarterly), MRY (Annual), or MRT (Trailing-twelve-months)
-        
+
     Returns:
         DataFrame containing balance sheet data or error message
     """
     if not symbol and not figi:
         return "Error: Either symbol or figi must be provided."
-    
+
     try:
         params = {}
         if symbol:
@@ -34,13 +34,13 @@ def get_balance_sheet(
             params["calendardate"] = calendardate
         if dimension:
             params["dimension"] = dimension
-            
+
         # Fetch data from NDAQ/BS table
-        data = nasdaqdatalink.get_table('NDAQ/BS', **params)
-        
+        data = nasdaqdatalink.get_table("NDAQ/BS", **params)
+
         if data.empty:
             return "No data found for the specified criteria."
-        
+
         return data
     except Exception as e:
         return f"Error fetching balance sheet data: {str(e)}"
@@ -49,16 +49,39 @@ def get_balance_sheet(
 def list_available_balance_sheet_fields() -> List[Dict[str, Any]]:
     """
     List available fields in the NDAQ/BS table with descriptions.
-    
+
     Returns:
         List of dictionaries containing field name, description, and type
     """
-    fields = [
-        {"name": "calendardate", "description": "The Calendar Date represents the normalized reportperiod", "type": "Date", "filterable": True, "primary_key": True},
-        {"name": "symbol", "description": "Symbol of the company", "type": "String", "filterable": True, "primary_key": True},
+    fields: List[Dict[str, Any]] = [
+        {
+            "name": "calendardate",
+            "description": "The Calendar Date represents the normalized reportperiod",
+            "type": "Date",
+            "filterable": True,
+            "primary_key": True,
+        },
+        {
+            "name": "symbol",
+            "description": "Symbol of the company",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "figi", "description": "Unique Identifier given by Bloomberg", "type": "String", "filterable": True},
-        {"name": "reportperiod", "description": "The Report Period represents the end date of the fiscal period", "type": "Date", "primary_key": True},
-        {"name": "dimension", "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)", "type": "String", "filterable": True, "primary_key": True},
+        {
+            "name": "reportperiod",
+            "description": "The Report Period represents the end date of the fiscal period",
+            "type": "Date",
+            "primary_key": True,
+        },
+        {
+            "name": "dimension",
+            "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "assets", "description": "Total assets recognized on the balance sheet", "type": "BigInt"},
         {"name": "bvps", "description": "Book Value Per Share (ratio between equity and shareswa)", "type": "Double"},
         {"name": "cashneq", "description": "Cash and equivalents on hand", "type": "BigInt"},
@@ -73,7 +96,11 @@ def list_available_balance_sheet_fields() -> List[Dict[str, Any]]:
         {"name": "inventory", "description": "Inventory expected to be sold within one year", "type": "BigInt"},
         {"name": "assetsnc", "description": "Non-current assets", "type": "BigInt"},
         {"name": "assetsc", "description": "Current assets", "type": "BigInt"},
-        {"name": "investments", "description": "Total marketable and non-marketable securities and other invested assets", "type": "BigInt"},
+        {
+            "name": "investments",
+            "description": "Total marketable and non-marketable securities and other invested assets",
+            "type": "BigInt",
+        },
         {"name": "ppnenet", "description": "Property, plant, and equipment (net of depreciation)", "type": "BigInt"},
         {"name": "intangibles", "description": "Intangible assets and goodwill", "type": "BigInt"},
         {"name": "tangibles", "description": "Tangible assets (assets minus intangibles)", "type": "BigInt"},
@@ -82,10 +109,18 @@ def list_available_balance_sheet_fields() -> List[Dict[str, Any]]:
         {"name": "liabilitiesc", "description": "Current liabilities", "type": "BigInt"},
         {"name": "debtc", "description": "Current portion of debt", "type": "BigInt"},
         {"name": "debtnc", "description": "Non-current portion of debt", "type": "BigInt"},
-        {"name": "deferredrev", "description": "Deferred revenue (unrecognized revenue from received payments)", "type": "BigInt"},
-        {"name": "retearn", "description": "Retained earnings (cumulative undistributed earnings/deficit)", "type": "BigInt"},
+        {
+            "name": "deferredrev",
+            "description": "Deferred revenue (unrecognized revenue from received payments)",
+            "type": "BigInt",
+        },
+        {
+            "name": "retearn",
+            "description": "Retained earnings (cumulative undistributed earnings/deficit)",
+            "type": "BigInt",
+        },
         {"name": "taxassets", "description": "Tax assets and receivables", "type": "BigInt"},
         {"name": "taxliabilities", "description": "Outstanding tax liabilities", "type": "BigInt"},
-        {"name": "cashnequsd", "description": "Cash and equivalents in USD", "type": "BigInt"}
+        {"name": "cashnequsd", "description": "Cash and equivalents in USD", "type": "BigInt"},
     ]
     return fields

--- a/nasdaq_data_link_mcp_os/resources/equities_360/balance_sheet.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/balance_sheet.py
@@ -39,7 +39,7 @@ def get_balance_sheet(
         data = nasdaqdatalink.get_table('NDAQ/BS', **params)
         
         if data.empty:
-            return f"No data found for the specified criteria."
+            return "No data found for the specified criteria."
         
         return data
     except Exception as e:

--- a/nasdaq_data_link_mcp_os/resources/equities_360/cash_flow.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/cash_flow.py
@@ -7,23 +7,23 @@ def get_cash_flow(
     symbol: Optional[str] = None,
     figi: Optional[str] = None,
     calendardate: Optional[str] = None,
-    dimension: Optional[str] = None
+    dimension: Optional[str] = None,
 ) -> Union[pd.DataFrame, str]:
     """
     Fetch cash flow statement data from Nasdaq Data Link E360 NDAQ/CF table.
-    
+
     Args:
         symbol: Stock ticker symbol (e.g., 'AAPL', 'MSFT')
         figi: Bloomberg FIGI identifier (e.g., 'BBG000BPH459')
         calendardate: Calendar date in YYYY-MM-DD format
         dimension: MRQ (Quarterly), MRY (Annual), or MRT (Trailing-twelve-months)
-        
+
     Returns:
         DataFrame containing cash flow statement data or error message
     """
     if not symbol and not figi:
         return "Error: Either symbol or figi must be provided."
-    
+
     try:
         params = {}
         if symbol:
@@ -34,13 +34,13 @@ def get_cash_flow(
             params["calendardate"] = calendardate
         if dimension:
             params["dimension"] = dimension
-            
+
         # Fetch data from NDAQ/CF table
-        data = nasdaqdatalink.get_table('NDAQ/CF', **params)
-        
+        data = nasdaqdatalink.get_table("NDAQ/CF", **params)
+
         if data.empty:
             return "No data found for the specified criteria."
-        
+
         return data
     except Exception as e:
         return f"Error fetching cash flow statement data: {str(e)}"
@@ -49,16 +49,39 @@ def get_cash_flow(
 def list_available_cash_flow_fields() -> List[Dict[str, Any]]:
     """
     List available fields in the NDAQ/CF table with descriptions.
-    
+
     Returns:
         List of dictionaries containing field name, description, and type
     """
-    fields = [
-        {"name": "calendardate", "description": "The Calendar Date represents the normalized reportperiod", "type": "Date", "filterable": True, "primary_key": True},
-        {"name": "symbol", "description": "Symbol of the company", "type": "String", "filterable": True, "primary_key": True},
+    fields: List[Dict[str, Any]] = [
+        {
+            "name": "calendardate",
+            "description": "The Calendar Date represents the normalized reportperiod",
+            "type": "Date",
+            "filterable": True,
+            "primary_key": True,
+        },
+        {
+            "name": "symbol",
+            "description": "Symbol of the company",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "figi", "description": "Unique Identifier given by Bloomberg", "type": "String", "filterable": True},
-        {"name": "reportperiod", "description": "The Report Period represents the end date of the fiscal period", "type": "Date", "primary_key": True},
-        {"name": "dimension", "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)", "type": "String", "filterable": True, "primary_key": True},
+        {
+            "name": "reportperiod",
+            "description": "The Report Period represents the end date of the fiscal period",
+            "type": "Date",
+            "primary_key": True,
+        },
+        {
+            "name": "dimension",
+            "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "opex", "description": "Operating expenses (excluding cost of revenue)", "type": "BigInt"},
         {"name": "ncfi", "description": "Net cash flow from investing activities", "type": "BigInt"},
         {"name": "ncff", "description": "Net cash flow from financing activities", "type": "BigInt"},
@@ -70,6 +93,6 @@ def list_available_cash_flow_fields() -> List[Dict[str, Any]]:
         {"name": "depamor", "description": "Depreciation, amortization, and accretion", "type": "BigInt"},
         {"name": "ncfcommon", "description": "Net cash flow from common equity changes", "type": "BigInt"},
         {"name": "ncfinv", "description": "Net cash flow from investments", "type": "BigInt"},
-        {"name": "debttoassets", "description": "Net cash flow from debt issuance/repayment", "type": "BigInt"}
+        {"name": "debttoassets", "description": "Net cash flow from debt issuance/repayment", "type": "BigInt"},
     ]
     return fields

--- a/nasdaq_data_link_mcp_os/resources/equities_360/cash_flow.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/cash_flow.py
@@ -39,7 +39,7 @@ def get_cash_flow(
         data = nasdaqdatalink.get_table('NDAQ/CF', **params)
         
         if data.empty:
-            return f"No data found for the specified criteria."
+            return "No data found for the specified criteria."
         
         return data
     except Exception as e:

--- a/nasdaq_data_link_mcp_os/resources/equities_360/corporate_actions.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/corporate_actions.py
@@ -4,20 +4,17 @@ import pandas as pd
 
 
 def get_corporate_actions(
-    symbol: Optional[str] = None,
-    figi: Optional[str] = None,
-    date: Optional[str] = None,
-    action: Optional[str] = None
+    symbol: Optional[str] = None, figi: Optional[str] = None, date: Optional[str] = None, action: Optional[str] = None
 ) -> Union[pd.DataFrame, str]:
     """
     Fetch corporate actions data from Nasdaq Data Link E360 NDAQ/CA table.
-    
+
     Args:
         symbol: Stock ticker symbol (e.g., 'AAPL', 'MSFT')
         figi: Bloomberg FIGI identifier (e.g., 'BBG000BPH459')
         date: Date of the corporate action in YYYY-MM-DD format
         action: Type of corporate action (e.g., 'split', 'merger')
-        
+
     Returns:
         DataFrame containing corporate actions data or error message
     """
@@ -31,13 +28,13 @@ def get_corporate_actions(
             params["date"] = date
         if action:
             params["action"] = action
-            
+
         # Fetch data from NDAQ/CA table
-        data = nasdaqdatalink.get_table('NDAQ/CA', **params)
-        
+        data = nasdaqdatalink.get_table("NDAQ/CA", **params)
+
         if data.empty:
             return "No corporate action data found for the specified criteria."
-        
+
         return data
     except Exception as e:
         return f"Error fetching corporate actions data: {str(e)}"
@@ -46,17 +43,44 @@ def get_corporate_actions(
 def list_available_corporate_action_fields() -> List[Dict[str, Any]]:
     """
     List available fields in the NDAQ/CA table with descriptions.
-    
+
     Returns:
         List of dictionaries containing field name, description, and type
     """
-    fields = [
-        {"name": "date", "description": "The date of the corporate action", "type": "Date", "filterable": True, "primary_key": True},
-        {"name": "symbol", "description": "Symbol of the company", "type": "String", "filterable": True, "primary_key": True},
+    fields: List[Dict[str, Any]] = [
+        {
+            "name": "date",
+            "description": "The date of the corporate action",
+            "type": "Date",
+            "filterable": True,
+            "primary_key": True,
+        },
+        {
+            "name": "symbol",
+            "description": "Symbol of the company",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "figi", "description": "Unique Identifier given by Bloomberg", "type": "String", "filterable": True},
-        {"name": "action", "description": "Corporate action type (e.g., 'split', 'merger')", "type": "String", "primary_key": True},
+        {
+            "name": "action",
+            "description": "Corporate action type (e.g., 'split', 'merger')",
+            "type": "String",
+            "primary_key": True,
+        },
         {"name": "value", "description": "The total USD value of the action", "type": "Double"},
-        {"name": "contrasymbol", "description": "The contra symbol of the action, or N/A if not applicable", "type": "String", "primary_key": True},
-        {"name": "contraname", "description": "The name of the contra company, or N/A if not applicable", "type": "String", "primary_key": True}
+        {
+            "name": "contrasymbol",
+            "description": "The contra symbol of the action, or N/A if not applicable",
+            "type": "String",
+            "primary_key": True,
+        },
+        {
+            "name": "contraname",
+            "description": "The name of the contra company, or N/A if not applicable",
+            "type": "String",
+            "primary_key": True,
+        },
     ]
     return fields

--- a/nasdaq_data_link_mcp_os/resources/equities_360/corporate_actions.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/corporate_actions.py
@@ -36,7 +36,7 @@ def get_corporate_actions(
         data = nasdaqdatalink.get_table('NDAQ/CA', **params)
         
         if data.empty:
-            return f"No corporate action data found for the specified criteria."
+            return "No corporate action data found for the specified criteria."
         
         return data
     except Exception as e:

--- a/nasdaq_data_link_mcp_os/resources/equities_360/fundamental_details.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/fundamental_details.py
@@ -7,23 +7,23 @@ def get_fundamental_details(
     symbol: Optional[str] = None,
     figi: Optional[str] = None,
     calendardate: Optional[str] = None,
-    dimension: Optional[str] = None
+    dimension: Optional[str] = None,
 ) -> Union[pd.DataFrame, str]:
     """
     Fetch detailed fundamental data from Nasdaq Data Link E360 NDAQ/FD table.
-    
+
     Args:
         symbol: Stock ticker symbol (e.g., 'AAPL', 'MSFT')
         figi: Bloomberg FIGI identifier (e.g., 'BBG000BPH459')
         calendardate: Calendar date in YYYY-MM-DD format
         dimension: MRQ (Quarterly), MRY (Annual), or MRT (Trailing-twelve-months)
-        
+
     Returns:
         DataFrame containing detailed fundamental data or error message
     """
     if not symbol and not figi:
         return "Error: Either symbol or figi must be provided."
-    
+
     try:
         params = {}
         if symbol:
@@ -34,13 +34,13 @@ def get_fundamental_details(
             params["calendardate"] = calendardate
         if dimension:
             params["dimension"] = dimension
-            
+
         # Fetch data from NDAQ/FD table
-        data = nasdaqdatalink.get_table('NDAQ/FD', **params)
-        
+        data = nasdaqdatalink.get_table("NDAQ/FD", **params)
+
         if data.empty:
             return "No data found for the specified criteria."
-        
+
         return data
     except Exception as e:
         return f"Error fetching fundamental details: {str(e)}"
@@ -49,52 +49,123 @@ def get_fundamental_details(
 def list_available_detail_fields() -> List[Dict[str, Any]]:
     """
     List available fields in the NDAQ/FD table with descriptions.
-    
+
     Returns:
         List of dictionaries containing field name, description, and type
     """
-    fields = [
-        {"name": "calendardate", "description": "The Calendar Date represents the normalized reportperiod", "type": "Date", "filterable": True, "primary_key": True},
-        {"name": "symbol", "description": "Symbol of the company", "type": "String", "filterable": True, "primary_key": True},
+    fields: List[Dict[str, Any]] = [
+        {
+            "name": "calendardate",
+            "description": "The Calendar Date represents the normalized reportperiod",
+            "type": "Date",
+            "filterable": True,
+            "primary_key": True,
+        },
+        {
+            "name": "symbol",
+            "description": "Symbol of the company",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "figi", "description": "Unique Identifier given by Bloomberg", "type": "String", "filterable": True},
-        {"name": "reportperiod", "description": "The Report Period represents the end date of the fiscal period", "type": "Date", "primary_key": True},
-        {"name": "dimension", "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)", "type": "String", "filterable": True, "primary_key": True},
-        {"name": "payables", "description": "A component of liabilities representing trade and non-trade payables", "type": "BigInt"},
-        {"name": "receivables", "description": "A component of assets representing trade and non-trade receivables", "type": "BigInt"},
-        {"name": "cashneq", "description": "A component of assets representing currency on hand and demand deposits", "type": "BigInt"},
+        {
+            "name": "reportperiod",
+            "description": "The Report Period represents the end date of the fiscal period",
+            "type": "Date",
+            "primary_key": True,
+        },
+        {
+            "name": "dimension",
+            "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
+        {
+            "name": "payables",
+            "description": "A component of liabilities representing trade and non-trade payables",
+            "type": "BigInt",
+        },
+        {
+            "name": "receivables",
+            "description": "A component of assets representing trade and non-trade receivables",
+            "type": "BigInt",
+        },
+        {
+            "name": "cashneq",
+            "description": "A component of assets representing currency on hand and demand deposits",
+            "type": "BigInt",
+        },
         {"name": "investmentsnc", "description": "The non-current portion of investments", "type": "BigInt"},
         {"name": "investmentsc", "description": "The current portion of investments", "type": "BigInt"},
-        {"name": "taxassets", "description": "A component of assets representing tax assets and receivables", "type": "BigInt"},
+        {
+            "name": "taxassets",
+            "description": "A component of assets representing tax assets and receivables",
+            "type": "BigInt",
+        },
         {"name": "ncfo", "description": "Cash inflow (outflow) from operating activities", "type": "BigInt"},
-        {"name": "capex", "description": "Cash inflow (outflow) associated with acquisition & disposal of long-lived assets", "type": "BigInt"},
+        {
+            "name": "capex",
+            "description": "Cash inflow (outflow) associated with acquisition & disposal of long-lived assets",
+            "type": "BigInt",
+        },
         {"name": "cashnequsd", "description": "Cash and equivalents in USD", "type": "BigInt"},
         {"name": "netincdis", "description": "Income from a disposal group, net of income tax", "type": "BigInt"},
         {"name": "debtc", "description": "The current portion of debt", "type": "BigInt"},
         {"name": "dps", "description": "Dividends declared per split-adjusted share of common stock", "type": "Double"},
         {"name": "retearn", "description": "Cumulative amount of undistributed earnings or deficit", "type": "BigInt"},
-        {"name": "ebitda", "description": "Earnings Before Interest, Taxes, Depreciation and Amortization", "type": "BigInt"},
+        {
+            "name": "ebitda",
+            "description": "Earnings Before Interest, Taxes, Depreciation and Amortization",
+            "type": "BigInt",
+        },
         {"name": "ebit", "description": "Earnings Before Interest and Tax", "type": "BigInt"},
         {"name": "equity", "description": "Total stockholders' equity", "type": "BigInt"},
-        {"name": "ncfbus", "description": "Cash inflow (outflow) from acquisition & disposal of businesses", "type": "BigInt"},
+        {
+            "name": "ncfbus",
+            "description": "Cash inflow (outflow) from acquisition & disposal of businesses",
+            "type": "BigInt",
+        },
         {"name": "depamor", "description": "Depreciation, amortization, and accretion", "type": "BigInt"},
-        {"name": "taxexp", "description": "Current and deferred income tax expense for continuing operations", "type": "BigInt"},
+        {
+            "name": "taxexp",
+            "description": "Current and deferred income tax expense for continuing operations",
+            "type": "BigInt",
+        },
         {"name": "sgna", "description": "Selling, general and administrative expenses", "type": "BigInt"},
         {"name": "rnd", "description": "Research and development expenses", "type": "BigInt"},
-        {"name": "opex", "description": "Operating expenses (sgna, rnd and other operating expenses)", "type": "BigInt"},
+        {
+            "name": "opex",
+            "description": "Operating expenses (sgna, rnd and other operating expenses)",
+            "type": "BigInt",
+        },
         {"name": "sbcomp", "description": "Non-cash, equity-based employee remuneration", "type": "BigInt"},
         {"name": "tangibles", "description": "Value of tangible assets (assets minus intangibles)", "type": "BigInt"},
         {"name": "intangibles", "description": "Carrying amounts of intangible assets and goodwill", "type": "BigInt"},
         {"name": "eps", "description": "Earnings per share as reported by the company", "type": "Double"},
         {"name": "ebt", "description": "Earnings Before Tax", "type": "BigInt"},
         {"name": "netinc", "description": "Net income attributable to the parent", "type": "BigInt"},
-        {"name": "opinc", "description": "Operating income (before interest, taxes and non-operating items)", "type": "BigInt"},
+        {
+            "name": "opinc",
+            "description": "Operating income (before interest, taxes and non-operating items)",
+            "type": "BigInt",
+        },
         {"name": "consolinc", "description": "Consolidated net income", "type": "BigInt"},
-        {"name": "inventory", "description": "Value of inventory expected to be sold within one year", "type": "BigInt"},
+        {
+            "name": "inventory",
+            "description": "Value of inventory expected to be sold within one year",
+            "type": "BigInt",
+        },
         {"name": "debtnc", "description": "The non-current portion of debt", "type": "BigInt"},
         {"name": "taxliabilities", "description": "Outstanding tax liabilities", "type": "BigInt"},
         {"name": "liabilitiesnc", "description": "The non-current portion of liabilities", "type": "BigInt"},
         {"name": "liabilities", "description": "Total liabilities", "type": "BigInt"},
-        {"name": "deferredrev", "description": "Consideration received but not recognized as revenue", "type": "BigInt"},
+        {
+            "name": "deferredrev",
+            "description": "Consideration received but not recognized as revenue",
+            "type": "BigInt",
+        },
         {"name": "accoci", "description": "Accumulated other comprehensive income", "type": "BigInt"},
         {"name": "ppnenet", "description": "Property, plant, and equipment (net of depreciation)", "type": "BigInt"},
         {"name": "pe1", "description": "Price to earnings ratio (price/eps)", "type": "Double"},
@@ -102,14 +173,26 @@ def list_available_detail_fields() -> List[Dict[str, Any]]:
         {"name": "grossmargin", "description": "Ratio between gross profit and revenue", "type": "Double"},
         {"name": "revenue", "description": "Total revenue from goods sold and services rendered", "type": "BigInt"},
         {"name": "intexp", "description": "Interest expense on borrowed funds", "type": "BigInt"},
-        {"name": "cor", "description": "Cost of revenue (goods produced and sold, services rendered)", "type": "BigInt"},
+        {
+            "name": "cor",
+            "description": "Cost of revenue (goods produced and sold, services rendered)",
+            "type": "BigInt",
+        },
         {"name": "ncfcommon", "description": "Cash flow from common equity changes", "type": "BigInt"},
         {"name": "netinccmn", "description": "Net income attributable to common shareholders", "type": "BigInt"},
         {"name": "ncfinv", "description": "Cash flow from investments", "type": "BigInt"},
         {"name": "ncff", "description": "Cash flow from financing activities", "type": "BigInt"},
-        {"name": "shareswa", "description": "Weighted average shares outstanding used to calculate EPS", "type": "BigInt"},
+        {
+            "name": "shareswa",
+            "description": "Weighted average shares outstanding used to calculate EPS",
+            "type": "BigInt",
+        },
         {"name": "epsusd", "description": "Earnings per share in USD", "type": "Double"},
-        {"name": "workingcapital", "description": "Difference between current assets and current liabilities", "type": "BigInt"},
+        {
+            "name": "workingcapital",
+            "description": "Difference between current assets and current liabilities",
+            "type": "BigInt",
+        },
         {"name": "invcap", "description": "Invested capital", "type": "BigInt"},
         {"name": "invcapavg", "description": "Average invested capital for the period", "type": "BigInt"},
         {"name": "roic", "description": "Return on Invested Capital (EBIT/invcapavg)", "type": "Double"},
@@ -123,6 +206,6 @@ def list_available_detail_fields() -> List[Dict[str, Any]]:
         {"name": "revenueusd", "description": "Revenue in USD", "type": "BigInt"},
         {"name": "debttoassets", "description": "Cash flow from debt issuance/repayment", "type": "BigInt"},
         {"name": "shareswadil", "description": "Weighted average diluted shares outstanding", "type": "BigInt"},
-        {"name": "sharesbas", "description": "Basic shares outstanding after stock splits", "type": "BigInt"}
+        {"name": "sharesbas", "description": "Basic shares outstanding after stock splits", "type": "BigInt"},
     ]
     return fields

--- a/nasdaq_data_link_mcp_os/resources/equities_360/fundamental_details.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/fundamental_details.py
@@ -39,7 +39,7 @@ def get_fundamental_details(
         data = nasdaqdatalink.get_table('NDAQ/FD', **params)
         
         if data.empty:
-            return f"No data found for the specified criteria."
+            return "No data found for the specified criteria."
         
         return data
     except Exception as e:

--- a/nasdaq_data_link_mcp_os/resources/equities_360/fundamentals.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/fundamentals.py
@@ -39,7 +39,7 @@ def get_fundamental_summary(
         data = nasdaqdatalink.get_table('NDAQ/FS', **params)
         
         if data.empty:
-            return f"No data found for the specified criteria."
+            return "No data found for the specified criteria."
         
         return data
     except Exception as e:

--- a/nasdaq_data_link_mcp_os/resources/equities_360/fundamentals.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/fundamentals.py
@@ -7,23 +7,23 @@ def get_fundamental_summary(
     symbol: Optional[str] = None,
     figi: Optional[str] = None,
     calendardate: Optional[str] = None,
-    dimension: Optional[str] = None
+    dimension: Optional[str] = None,
 ) -> Union[pd.DataFrame, str]:
     """
     Fetch fundamental summary data from Nasdaq Data Link E360 NDAQ/FS table.
-    
+
     Args:
         symbol: Stock ticker symbol (e.g., 'AAPL', 'MSFT')
         figi: Bloomberg FIGI identifier (e.g., 'BBG000BPH459')
         calendardate: Calendar date in YYYY-MM-DD format
         dimension: MRQ (Quarterly), MRY (Annual), or MRT (Trailing-twelve-months)
-        
+
     Returns:
         DataFrame containing fundamental data or error message
     """
     if not symbol and not figi:
         return "Error: Either symbol or figi must be provided."
-    
+
     try:
         params = {}
         if symbol:
@@ -34,13 +34,13 @@ def get_fundamental_summary(
             params["calendardate"] = calendardate
         if dimension:
             params["dimension"] = dimension
-            
+
         # Fetch data from NDAQ/FS table
-        data = nasdaqdatalink.get_table('NDAQ/FS', **params)
-        
+        data = nasdaqdatalink.get_table("NDAQ/FS", **params)
+
         if data.empty:
             return "No data found for the specified criteria."
-        
+
         return data
     except Exception as e:
         return f"Error fetching fundamental summary: {str(e)}"
@@ -49,32 +49,67 @@ def get_fundamental_summary(
 def list_available_fundamental_fields() -> List[Dict[str, Any]]:
     """
     List available fields in the NDAQ/FS table with descriptions.
-    
+
     Returns:
         List of dictionaries containing field name, description, and type
     """
-    fields = [
-        {"name": "calendardate", "description": "The Calendar Date represents the normalized reportperiod", "type": "Date", "filterable": True, "primary_key": True},
-        {"name": "symbol", "description": "Symbol of the company", "type": "String", "filterable": True, "primary_key": True},
+    fields: List[Dict[str, Any]] = [
+        {
+            "name": "calendardate",
+            "description": "The Calendar Date represents the normalized reportperiod",
+            "type": "Date",
+            "filterable": True,
+            "primary_key": True,
+        },
+        {
+            "name": "symbol",
+            "description": "Symbol of the company",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "figi", "description": "Unique Identifier given by Bloomberg", "type": "String", "filterable": True},
-        {"name": "reportperiod", "description": "The Report Period represents the end date of the fiscal period", "type": "Date", "primary_key": True},
-        {"name": "dimension", "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)", "type": "String", "filterable": True, "primary_key": True},
+        {
+            "name": "reportperiod",
+            "description": "The Report Period represents the end date of the fiscal period",
+            "type": "Date",
+            "primary_key": True,
+        },
+        {
+            "name": "dimension",
+            "description": "Dimensional view of data (MRQ: Quarterly, MRY: annual, MRT: trailing-twelve-months)",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "fcfps", "description": "Free Cash Flow per Share", "type": "Double"},
         {"name": "ps", "description": "Price to Sales ratio between marketcap and revenue", "type": "Double"},
         {"name": "pe", "description": "Price to Earnings ratio between marketcap and netinccmn", "type": "Double"},
-        {"name": "revenue", "description": "Amount of Revenue recognized from goods sold, services rendered, etc.", "type": "BigInt"},
+        {
+            "name": "revenue",
+            "description": "Amount of Revenue recognized from goods sold, services rendered, etc.",
+            "type": "BigInt",
+        },
         {"name": "currentratio", "description": "The ratio between assetsc and liabilitiesc", "type": "Double"},
         {"name": "de", "description": "Debt to Equity ratio between liabilities and equity", "type": "Double"},
         {"name": "roa", "description": "Return on Assets (netinccmn relative to total assets)", "type": "Double"},
         {"name": "roe", "description": "Return on Equity (netinccmn as percentage of equityavg)", "type": "Double"},
         {"name": "ros", "description": "Return on Sales (ebit divided by revenue)", "type": "Double"},
         {"name": "gp", "description": "Gross Profit (revenue less cost of revenue)", "type": "BigInt"},
-        {"name": "opinc", "description": "Operating income (before deduction of intexp, taxexp, etc.)", "type": "BigInt"},
+        {
+            "name": "opinc",
+            "description": "Operating income (before deduction of intexp, taxexp, etc.)",
+            "type": "BigInt",
+        },
         {"name": "netmargin", "description": "Net Margin (ratio between netinccmn and revenue)", "type": "Double"},
-        {"name": "ebitda", "description": "Earnings Before Interest, Taxes, Depreciation and Amortization", "type": "BigInt"},
+        {
+            "name": "ebitda",
+            "description": "Earnings Before Interest, Taxes, Depreciation and Amortization",
+            "type": "BigInt",
+        },
         {"name": "bvps", "description": "Book Value Per Share (ratio between equity and shareswa)", "type": "Double"},
         {"name": "evebit", "description": "Enterprise Value to EBIT ratio", "type": "BigInt"},
         {"name": "evebitda", "description": "Enterprise Value to EBITDA ratio", "type": "Double"},
-        {"name": "tbvps", "description": "Tangible Book Value Per Share", "type": "Double"}
+        {"name": "tbvps", "description": "Tangible Book Value Per Share", "type": "Double"},
     ]
     return fields

--- a/nasdaq_data_link_mcp_os/resources/equities_360/reference_data.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/reference_data.py
@@ -28,7 +28,7 @@ def get_reference_data(
         data = nasdaqdatalink.get_table('NDAQ/RD', **params)
         
         if data.empty:
-            return f"No reference data found for the specified criteria."
+            return "No reference data found for the specified criteria."
         
         return data
     except Exception as e:

--- a/nasdaq_data_link_mcp_os/resources/equities_360/reference_data.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/reference_data.py
@@ -3,17 +3,14 @@ import nasdaqdatalink
 import pandas as pd
 
 
-def get_reference_data(
-    symbol: Optional[str] = None,
-    figi: Optional[str] = None
-) -> Union[pd.DataFrame, str]:
+def get_reference_data(symbol: Optional[str] = None, figi: Optional[str] = None) -> Union[pd.DataFrame, str]:
     """
     Fetch reference data from Nasdaq Data Link E360 NDAQ/RD table.
-    
+
     Args:
         symbol: Stock ticker symbol (e.g., 'AAPL', 'MSFT')
         figi: Bloomberg FIGI identifier (e.g., 'BBG000BPH459')
-        
+
     Returns:
         DataFrame containing reference data or error message
     """
@@ -23,13 +20,13 @@ def get_reference_data(
             params["symbol"] = symbol
         if figi:
             params["figi"] = figi
-            
+
         # Fetch data from NDAQ/RD table
-        data = nasdaqdatalink.get_table('NDAQ/RD', **params)
-        
+        data = nasdaqdatalink.get_table("NDAQ/RD", **params)
+
         if data.empty:
             return "No reference data found for the specified criteria."
-        
+
         return data
     except Exception as e:
         return f"Error fetching reference data: {str(e)}"
@@ -38,16 +35,30 @@ def get_reference_data(
 def list_available_reference_fields() -> List[Dict[str, Any]]:
     """
     List available fields in the NDAQ/RD table with descriptions.
-    
+
     Returns:
         List of dictionaries containing field name, description, and type
     """
-    fields = [
-        {"name": "symbol", "description": "Symbol of the company", "type": "String", "filterable": True, "primary_key": True},
+    fields: List[Dict[str, Any]] = [
+        {
+            "name": "symbol",
+            "description": "Symbol of the company",
+            "type": "String",
+            "filterable": True,
+            "primary_key": True,
+        },
         {"name": "figi", "description": "Unique Identifier given by Bloomberg", "type": "String", "filterable": True},
-        {"name": "exchange", "description": "The exchange on which the security trades (e.g., 'NASDAQ', 'NYSE')", "type": "String"},
+        {
+            "name": "exchange",
+            "description": "The exchange on which the security trades (e.g., 'NASDAQ', 'NYSE')",
+            "type": "String",
+        },
         {"name": "category", "description": "Security category (e.g., 'Domestic Common Stock')", "type": "String"},
-        {"name": "cusips", "description": "Security identifier (space delimited for multiple identifiers)", "type": "String"},
+        {
+            "name": "cusips",
+            "description": "Security identifier (space delimited for multiple identifiers)",
+            "type": "String",
+        },
         {"name": "name", "description": "Full legal name of the company", "type": "String"},
         {"name": "industry", "description": "Industry classification based on SIC codes", "type": "String"},
         {"name": "companysite", "description": "URL of the company website", "type": "String"},
@@ -56,6 +67,6 @@ def list_available_reference_fields() -> List[Dict[str, Any]]:
         {"name": "sector_2", "description": "Secondary sector exposure (TIIC level 1)", "type": "String"},
         {"name": "secfilings", "description": "URL to SEC filings with Central Index Key (CIK)", "type": "String"},
         {"name": "siccode", "description": "Standard Industrial Classification code", "type": "Integer"},
-        {"name": "location", "description": "Company location as registered with the SEC", "type": "String"}
+        {"name": "location", "description": "Company location as registered with the SEC", "type": "String"},
     ]
     return fields

--- a/nasdaq_data_link_mcp_os/resources/equities_360/statistics.py
+++ b/nasdaq_data_link_mcp_os/resources/equities_360/statistics.py
@@ -31,7 +31,7 @@ def get_company_stats(
         data = nasdaqdatalink.get_table('NDAQ/STAT', **params)
         
         if data.empty:
-            return f"No data found for the specified criteria."
+            return "No data found for the specified criteria."
         
         return data
     except Exception as e:

--- a/nasdaq_data_link_mcp_os/resources/rtat/retail_activity.py
+++ b/nasdaq_data_link_mcp_os/resources/rtat/retail_activity.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Optional
 import nasdaqdatalink
 
 

--- a/nasdaq_data_link_mcp_os/resources/trade_summary/trade_data.py
+++ b/nasdaq_data_link_mcp_os/resources/trade_summary/trade_data.py
@@ -1,4 +1,4 @@
-from typing import Optional, Dict, Any
+from typing import Dict, Any
 import nasdaqdatalink
 
 

--- a/nasdaq_data_link_mcp_os/resources/world_data_bank/indicators.py
+++ b/nasdaq_data_link_mcp_os/resources/world_data_bank/indicators.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import Any, Dict, List, Union
 import nasdaqdatalink
 
 
@@ -6,28 +6,25 @@ import nasdaqdatalink
 def load_indicator_metadata() -> Dict[str, Dict[str, str]]:
     """Load indicator metadata from WB/METADATA dataset."""
     try:
-        metadata_df = nasdaqdatalink.get_table('WB/METADATA')
-        
+        metadata_df = nasdaqdatalink.get_table("WB/METADATA")
+
         # Convert DataFrame to dictionary
         metadata_dict = {}
         for _, row in metadata_df.iterrows():
-            series_id = row.get('series_id', '')
-            name = row.get('name', '')
-            description = row.get('description', '')
-            
+            series_id = row.get("series_id", "")
+            name = row.get("name", "")
+            description = row.get("description", "")
+
             if series_id:
-                metadata_dict[series_id] = {
-                    'name': name,
-                    'description': description
-                }
-        
+                metadata_dict[series_id] = {"name": name, "description": description}
+
         return metadata_dict
     except Exception as e:
         print(f"Error loading World Bank metadata: {e}")
         return {}
 
 
-def get_indicator_value(country: str, indicator: str) -> str:
+def get_indicator_value(country: str, indicator: str) -> Union[str, Dict[str, Any]]:
     """
     Fetch the most recent value of a World Bank development indicator for a given country.
 
@@ -43,41 +40,41 @@ def get_indicator_value(country: str, indicator: str) -> str:
     """
     # Check if the indicator is a direct code or needs to be searched
     metadata = load_indicator_metadata()
-    
+
     # If indicator is not a direct code, try to find a match
     if indicator not in metadata:
         # Search for matching indicators
         matches = search_indicators(indicator)
-        
+
         if not matches:
             return f"No indicators found matching '{indicator}'. Try a different search term."
-        
+
         # Use the first match's series_id
         indicator = matches[0].split(":")[0].strip()
-    
+
     try:
         df = nasdaqdatalink.get_table(
             "WB/DATA",
             series_id=indicator,
             country_code=country,
         )
-        
+
         if df.empty:
             return f"No data found for indicator '{indicator}' in country '{country}'."
-        
+
         # Return the most recent data
-        df = df.sort_values('year', ascending=False)
-        
+        df = df.sort_values("year", ascending=False)
+
         # Format the response
-        indicator_name = metadata.get(indicator, {}).get('name', indicator)
+        indicator_name = metadata.get(indicator, {}).get("name", indicator)
         most_recent = df.iloc[0]
         return {
-            'indicator': indicator,
-            'indicator_name': indicator_name,
-            'country': country,
-            'year': int(most_recent.get('year')),
-            'value': float(most_recent.get('value')),
-            'all_data': df[['year', 'value']].to_dict('records')
+            "indicator": indicator,
+            "indicator_name": indicator_name,
+            "country": country,
+            "year": int(most_recent.get("year")),
+            "value": float(most_recent.get("value")),
+            "all_data": df[["year", "value"]].to_dict("records"),
         }
     except Exception as e:
         return f"Error fetching data for indicator '{indicator}': {str(e)}"
@@ -91,17 +88,15 @@ def search_indicators(keyword: str) -> List[str]:
     metadata = load_indicator_metadata()
     keyword_lower = keyword.lower()
     matches = []
-    
+
     for series_id, info in metadata.items():
-        name = info.get('name', '')
-        description = info.get('description', '')
-        
+        name = info.get("name", "")
+        description = info.get("description", "")
+
         # Search in both name and description
-        if (keyword_lower in name.lower() or 
-            keyword_lower in description.lower() or 
-            keyword_lower in series_id.lower()):
+        if keyword_lower in name.lower() or keyword_lower in description.lower() or keyword_lower in series_id.lower():
             matches.append(f"{series_id}: {name} - {description}")
-    
+
     # Return up to 10 matches
     return matches[:10]
 
@@ -113,10 +108,10 @@ def list_all_indicators() -> List[str]:
     """
     metadata = load_indicator_metadata()
     results = []
-    
+
     for series_id, info in metadata.items():
-        name = info.get('name', '')
-        description = info.get('description', '')
+        name = info.get("name", "")
+        description = info.get("description", "")
         results.append(f"{series_id}: {name} - {description}")
-    
+
     return results

--- a/nasdaq_data_link_mcp_os/server.py
+++ b/nasdaq_data_link_mcp_os/server.py
@@ -1,4 +1,4 @@
-from typing import List, Dict, Optional
+from typing import Any, Dict, List, Optional, Union
 from mcp.server.fastmcp import FastMCP
 from nasdaq_data_link_mcp_os.resources.common.countries import get_country_code
 from nasdaq_data_link_mcp_os.resources.world_data_bank.indicators import (
@@ -50,7 +50,7 @@ from nasdaq_data_link_mcp_os.resources.nfn.fund_master_report import (
     get_mfrprb_data,
     get_mfrpa_data,
     get_mfrpm_data,
-    get_mfrmf_data
+    get_mfrmf_data,
 )
 from nasdaq_data_link_mcp_os.config import initialize_api
 
@@ -61,7 +61,7 @@ mcp = FastMCP("NASDAQ Data Link MCP", dependencies=["nasdaq-data-link", "pycount
 
 
 @mcp.tool()
-def get_indicator_value(country: str, indicator: str) -> str:
+def get_indicator_value(country: str, indicator: str) -> Union[str, Dict[str, Any]]:
     return get_wb_indicator(country, indicator)
 
 
@@ -81,7 +81,7 @@ def search_worldbank_indicators(keyword: str) -> List[str]:
 
 
 @mcp.tool()
-def get_rtat10(dates: str, tickers: str = None):
+def get_rtat10(dates: str, tickers: Optional[str] = None):
     """
     Retrieves Retail Trading Activity Tracker 10 (RTAT10) data for specific dates and optional tickers.
 
@@ -91,7 +91,7 @@ def get_rtat10(dates: str, tickers: str = None):
 
 
 @mcp.tool()
-def get_rtat(dates: str, tickers: str = None):
+def get_rtat(dates: str, tickers: Optional[str] = None):
     """
     Retrieves Retail Trading Activity (RTAT) data for specific dates and optional tickers.
 
@@ -315,9 +315,7 @@ def list_corporate_action_fields() -> List[Dict[str, str]]:
 
 
 @mcp.tool()
-def get_company_reference_data(
-    symbol: Optional[str] = None, figi: Optional[str] = None
-):
+def get_company_reference_data(symbol: Optional[str] = None, figi: Optional[str] = None):
     """
     Retrieves company reference data from Nasdaq Equities 360 Reference Data database.
 
@@ -361,19 +359,20 @@ def get_trade_summary_data(**kwargs):
 
 
 @mcp.tool()
-def get_fund_master_report(fund_id: Optional[str] = None, name: Optional[str] = None, 
-                         investment_company_type: Optional[str] = None, **kwargs):
+def get_fund_master_report(
+    fund_id: Optional[str] = None, name: Optional[str] = None, investment_company_type: Optional[str] = None, **kwargs
+):
     """
     Retrieves Fund Master Report (NFN/MFRFM) data from Nasdaq Fund Network.
-    
+
     Provides basic information about live NFN funds, mutual funds and closed-end funds.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - name: Optional fund name
       - investment_company_type: Optional investment company type (N-1A for Open-Ended mutual funds, N-2 for Closed-End funds)
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_fund_master_report(fund_id='12345')
     Example: get_fund_master_report(investment_company_type='N-1A')
     """
@@ -381,20 +380,21 @@ def get_fund_master_report(fund_id: Optional[str] = None, name: Optional[str] = 
 
 
 @mcp.tool()
-def get_fund_information(fund_id: Optional[str] = None, name: Optional[str] = None, 
-                       investment_company_type: Optional[str] = None, **kwargs):
+def get_fund_information(
+    fund_id: Optional[str] = None, name: Optional[str] = None, investment_company_type: Optional[str] = None, **kwargs
+):
     """
     Retrieves Fund Information Report (NFN/MFRFI) data from Nasdaq Fund Network.
-    
+
     Provides detailed information about funds including investment strategy, objectives,
     and classification data.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - name: Optional fund name
       - investment_company_type: Optional investment company type (N-1A for Open-Ended mutual funds, N-2 for Closed-End funds)
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_fund_information(fund_id='12345')
     Example: get_fund_information(investment_company_type='N-1A')
     """
@@ -405,14 +405,14 @@ def get_fund_information(fund_id: Optional[str] = None, name: Optional[str] = No
 def get_share_class_master(fund_id: Optional[str] = None, name: Optional[str] = None, **kwargs):
     """
     Retrieves Fund Share Class Master (NFN/MFRSM) data from Nasdaq Fund Network.
-    
+
     Provides basic information about fund share classes, including identifiers and name.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - name: Optional fund name
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_share_class_master(fund_id='12345')
     Example: get_share_class_master(name='Growth Fund')
     """
@@ -423,15 +423,15 @@ def get_share_class_master(fund_id: Optional[str] = None, name: Optional[str] = 
 def get_share_class_information(fund_id: Optional[str] = None, ticker: Optional[str] = None, **kwargs):
     """
     Retrieves Fund Share Class Information (NFN/MFRSI) data from Nasdaq Fund Network.
-    
+
     Provides detailed information about fund share classes including minimum investments,
     fees, and other attributes.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_share_class_information(fund_id='12345')
     Example: get_share_class_information(ticker='ABCDX')
     """
@@ -439,20 +439,25 @@ def get_share_class_information(fund_id: Optional[str] = None, ticker: Optional[
 
 
 @mcp.tool()
-def get_price_history(fund_id: Optional[str] = None, ticker: Optional[str] = None, 
-                    start_date: Optional[str] = None, end_date: Optional[str] = None, **kwargs):
+def get_price_history(
+    fund_id: Optional[str] = None,
+    ticker: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    **kwargs,
+):
     """
     Retrieves Fund Price History (NFN/MFRPH) data from Nasdaq Fund Network.
-    
+
     Provides historical NAV, offering, and redemption prices for funds.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - start_date: Optional start date for price history (YYYY-MM-DD format)
       - end_date: Optional end date for price history (YYYY-MM-DD format)
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_price_history(ticker='ABCDX', start_date='2024-01-01', end_date='2024-04-30')
     Example: get_price_history(fund_id='12345')
     """
@@ -460,20 +465,25 @@ def get_price_history(fund_id: Optional[str] = None, ticker: Optional[str] = Non
 
 
 @mcp.tool()
-def get_recent_price_history(fund_id: Optional[str] = None, ticker: Optional[str] = None, 
-                           start_date: Optional[str] = None, end_date: Optional[str] = None, **kwargs):
+def get_recent_price_history(
+    fund_id: Optional[str] = None,
+    ticker: Optional[str] = None,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None,
+    **kwargs,
+):
     """
     Retrieves recent Fund Price History (NFN/MFRPH10) data from Nasdaq Fund Network.
-    
+
     Provides historical NAV, offering, and redemption prices for funds for the last 10 trading days.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - start_date: Optional start date for price history (YYYY-MM-DD format)
       - end_date: Optional end date for price history (YYYY-MM-DD format)
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_recent_price_history(ticker='ABCDX')
     Example: get_recent_price_history(fund_id='12345')
     """
@@ -484,14 +494,14 @@ def get_recent_price_history(fund_id: Optional[str] = None, ticker: Optional[str
 def get_performance_statistics(fund_id: Optional[str] = None, ticker: Optional[str] = None, **kwargs):
     """
     Retrieves Fund Performance Statistics (NFN/MFRPS) data from Nasdaq Fund Network.
-    
+
     Provides performance returns for various time periods (1mo, 3mo, YTD, 1yr, 3yr, etc.).
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_performance_statistics(ticker='ABCDX')
     Example: get_performance_statistics(fund_id='12345')
     """
@@ -502,14 +512,14 @@ def get_performance_statistics(fund_id: Optional[str] = None, ticker: Optional[s
 def get_performance_benchmark(fund_id: Optional[str] = None, ticker: Optional[str] = None, **kwargs):
     """
     Retrieves Fund Performance Benchmark (NFN/MFRPRB) data from Nasdaq Fund Network.
-    
+
     Provides information about fund benchmark indexes used for performance comparison.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_performance_benchmark(ticker='ABCDX')
     Example: get_performance_benchmark(fund_id='12345')
     """
@@ -520,14 +530,14 @@ def get_performance_benchmark(fund_id: Optional[str] = None, ticker: Optional[st
 def get_performance_analytics(fund_id: Optional[str] = None, ticker: Optional[str] = None, **kwargs):
     """
     Retrieves Fund Performance Analytics (NFN/MFRPA) data from Nasdaq Fund Network.
-    
+
     Provides analytical metrics such as alpha, beta, R-squared, Sharpe ratio, etc.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_performance_analytics(ticker='ABCDX')
     Example: get_performance_analytics(fund_id='12345')
     """
@@ -538,14 +548,14 @@ def get_performance_analytics(fund_id: Optional[str] = None, ticker: Optional[st
 def get_fees_and_expenses(fund_id: Optional[str] = None, ticker: Optional[str] = None, **kwargs):
     """
     Retrieves Fund Fee and Expense Data (NFN/MFRPM) from Nasdaq Fund Network.
-    
+
     Provides information about fund fees, expenses, and sales charges.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_fees_and_expenses(ticker='ABCDX')
     Example: get_fees_and_expenses(fund_id='12345')
     """
@@ -556,14 +566,14 @@ def get_fees_and_expenses(fund_id: Optional[str] = None, ticker: Optional[str] =
 def get_monthly_flows(fund_id: Optional[str] = None, ticker: Optional[str] = None, **kwargs):
     """
     Retrieves Fund Monthly Flows (NFN/MFRMF) data from Nasdaq Fund Network.
-    
+
     Provides historical fund flow data on a monthly basis.
-    
+
     Parameters:
-      - fund_id: Optional unique fund identifier 
+      - fund_id: Optional unique fund identifier
       - ticker: Optional ticker symbol
       - Additional parameters supported by the Nasdaq Data Link API
-      
+
     Example: get_monthly_flows(ticker='ABCDX')
     Example: get_monthly_flows(fund_id='12345')
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,9 +17,16 @@ classifiers = [
 ]
 dependencies = ["mcp[cli]>=1.6.0", "nasdaq-data-link", "pycountry"]
 
+[project.optional-dependencies]
+dev = ["ruff"]
+
 [tool.setuptools]
 packages = ["nasdaq_data_link_mcp_os"]
 
 [project.urls]
 "Homepage" = "https://github.com/stefanoamorelli/nasdaq-data-link-mcp"
 "Bug Tracker" = "https://github.com/stefanoamorelli/nasdaq-data-link-mcp/issues"
+
+[tool.ruff]
+target-version = "py311"
+line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = ["mcp[cli]>=1.6.0", "nasdaq-data-link", "pycountry"]
 
 [project.optional-dependencies]
-dev = ["ruff"]
+dev = ["ruff", "mypy"]
 
 [tool.setuptools]
 packages = ["nasdaq_data_link_mcp_os"]
@@ -30,3 +30,12 @@ packages = ["nasdaq_data_link_mcp_os"]
 [tool.ruff]
 target-version = "py311"
 line-length = 120
+
+[tool.ruff.format]
+quote-style = "double"
+
+[tool.mypy]
+python_version = "3.11"
+ignore_missing_imports = true
+show_error_codes = true
+pretty = true


### PR DESCRIPTION
## Summary
- add optional dev dependency `mypy`
- configure ruff formatting and mypy
- implement missing type hints
- check formatting and linting in CI
- add a workflow for mypy

## Testing
- `ruff format --check .`
- `ruff check .`
- `mypy nasdaq_data_link_mcp_os`