### PR TITLE
[Chore] Add ORCID ID to author information

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -3,6 +3,7 @@ message: "If you use this software, please cite it as below."
 authors:
   - family-names: Amorelli
     given-names: Stefano
+    orcid: 0009-0004-4917-0999
 title: "Nasdaq Data Link MCP (Model Context Protocol) Server"
 version: 1.0.0
 date-released: 2025-04-06


### PR DESCRIPTION
## Summary
- Added ORCID identifier (0009-0004-4917-0999) to the author information in CITATION.cff
- This improves author attribution and makes citations more accurate and verifiable

## Changes Made
- Updated `CITATION.cff` to include the `orcid` field under the author section

## Why This Change?
ORCID IDs provide persistent digital identifiers for researchers, ensuring proper attribution across publications and improving the discoverability of work. Including ORCID in citation files is a best practice for academic and research software.

## Test Plan
- [x] Verified CITATION.cff format is valid
- [x] Confirmed ORCID ID is correctly formatted (0009-0004-4917-0999)